### PR TITLE
Fix sed pattern escaping in issue-opened workflow

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -29,11 +29,11 @@ jobs:
           # Load the prompt file
           PROMPT=$(cat .github/prompts/duplicate-check.prompt.txt)
           # Replace GitHub template variables with actual values
-          # Escape $ and { } for sed, use # as delimiter to avoid conflicts
+          # Use literal braces (no escaping) - sed treats { } as literal in basic regex
           REPO_VALUE="${{ github.repository }}"
           ISSUE_NUM="${{ github.event.issue.number }}"
-          PROMPT=$(echo "$PROMPT" | sed "s#\$\{\{ github.repository \}\}#${REPO_VALUE}#g")
-          PROMPT=$(echo "$PROMPT" | sed "s#\$\{\{ github.event.issue.number \}\}#${ISSUE_NUM}#g")
+          PROMPT=$(echo "$PROMPT" | sed "s#\${{ github.repository }}#${REPO_VALUE}#g")
+          PROMPT=$(echo "$PROMPT" | sed "s#\${{ github.event.issue.number }}#${ISSUE_NUM}#g")
           # Output the prompt for use in next step
           {
             echo 'prompt<<EOF'


### PR DESCRIPTION
## Problem
The 'Load and Prepare Prompt' step was failing with:
```
sed: -e expression #1, char 45: Invalid content of \{\}
```

## Root Cause
The sed pattern was using `\{` and `\}` which are quantifier syntax in sed (e.g., `\{1,3\}`), not literal braces. When sed encountered `\{` followed by `\}` without a valid quantifier, it threw an error.

## Solution
Changed the sed patterns to use literal braces without escaping:
- Before: `sed "s#\$\{\{ github.repository \}\}#${REPO_VALUE}#g"`
- After: `sed "s#\${{ github.repository }}#${REPO_VALUE}#g"`

In basic regex mode, `{` and `}` are literal characters and don't need escaping.

## Testing
- Verified locally that the sed pattern correctly replaces template variables
- Tested with both `${{ github.repository }}` and `${{ github.event.issue.number }}` patterns

Fixes the workflow failure at: https://github.com/kenjpais/okd/actions/runs/21138261498/job/60785536957