### PR TITLE
Fix workflow: Use placeholders to avoid GitHub Actions ${{ }} expansion issue

### DIFF
--- a/.github/prompts/duplicate-check.prompt.txt
+++ b/.github/prompts/duplicate-check.prompt.txt
@@ -3,8 +3,8 @@ You're an issue triage assistant for GitHub issues.
 IMPORTANT: Don't post any comments or messages to the issue. Your only action should be to apply labels.
 
 Issue Information:
-- REPO: ${{ github.repository }}
-- ISSUE_NUMBER: ${{ github.event.issue.number }}
+- REPO: __REPO_PLACEHOLDER__
+- ISSUE_NUMBER: __ISSUE_NUMBER_PLACEHOLDER__
 
 TASK:
 1. First, fetch the list of labels available in this repository by running: `gh label list`. Run exactly this command with nothing else.

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -28,12 +28,12 @@ jobs:
         run: |
           # Load the prompt file
           PROMPT=$(cat .github/prompts/duplicate-check.prompt.txt)
-          # Replace GitHub template variables with actual values
-          # Use literal braces (no escaping) - sed treats { } as literal in basic regex
+          # Replace placeholders with actual values
+          # Using placeholders avoids GitHub Actions expanding ${{ }} in YAML before sed runs
           REPO_VALUE="${{ github.repository }}"
           ISSUE_NUM="${{ github.event.issue.number }}"
-          PROMPT=$(echo "$PROMPT" | sed "s#\${{ github.repository }}#${REPO_VALUE}#g")
-          PROMPT=$(echo "$PROMPT" | sed "s#\${{ github.event.issue.number }}#${ISSUE_NUM}#g")
+          PROMPT=$(echo "$PROMPT" | sed "s|__REPO_PLACEHOLDER__|${REPO_VALUE}|g")
+          PROMPT=$(echo "$PROMPT" | sed "s|__ISSUE_NUMBER_PLACEHOLDER__|${ISSUE_NUM}|g")
           # Output the prompt for use in next step
           {
             echo 'prompt<<EOF'


### PR DESCRIPTION
## Problem
The 'Load and Prepare Prompt' step was failing with:
```
sed: -e expression #1, char 12: Invalid back reference
```

## Root Cause
GitHub Actions expands `${{ }}` expressions in YAML before the shell script runs. When we tried to match `${{ github.repository }}` in sed, GitHub Actions expanded it to the actual repository name first, causing the sed pattern to become invalid (e.g., `sed "s#\kenjpais/okd#..."` where `\k` is interpreted as a back reference).

## Solution
Changed the prompt file to use placeholders (`__REPO_PLACEHOLDER__` and `__ISSUE_NUMBER_PLACEHOLDER__`) instead of `${{ }}` expressions. The workflow now replaces these placeholders with actual values using simple sed commands that don't conflict with GitHub Actions expansion.

## Changes
- Updated `.github/prompts/duplicate-check.prompt.txt` to use placeholders
- Updated `.github/workflows/issue-opened.yml` to replace placeholders instead of `${{ }}` patterns

This approach is cleaner and avoids all escaping issues.